### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-pypi.yml
+++ b/.github/workflows/python-pypi.yml
@@ -1,4 +1,6 @@
 name: Python package
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/mpol1t/async-websocket-pool/security/code-scanning/1](https://github.com/mpol1t/async-websocket-pool/security/code-scanning/1)

To fix the problem, explicitly limit the permissions assigned to the workflow. The best way is to add a `permissions` block with the least required access. For this workflow, adding it at the root level ensures that all jobs have restricted access unless otherwise specified. The recommended minimal permission for this scenario is `contents: read`. This line should be inserted directly after the workflow's name (after line 1 in this case).

No method definitions or imports are required; this is a configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
